### PR TITLE
Add key to table rows in ui/reference

### DIFF
--- a/src/klangmeister/ui/reference.cljs
+++ b/src/klangmeister/ui/reference.cljs
@@ -10,6 +10,7 @@
    [:tbody
     (map
       (fn [[name [description usage]]]
+        ^{:key name}
         [:tr
          [:td {:class "name"} name]
          [:td description]


### PR DESCRIPTION
A tiny change that fixes reagent warnings related to table rows not having unique keys. 